### PR TITLE
Add simple login feature

### DIFF
--- a/src/main/java/forest/user/service/UserService.java
+++ b/src/main/java/forest/user/service/UserService.java
@@ -1,0 +1,7 @@
+package forest.user.service;
+
+import forest.user.vo.UserVo;
+
+public interface UserService {
+    UserVo login(String username, String password);
+}

--- a/src/main/java/forest/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/forest/user/service/impl/UserServiceImpl.java
@@ -1,0 +1,26 @@
+package forest.user.service.impl;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.mybatis.spring.SqlSessionTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import forest.user.service.UserService;
+import forest.user.vo.UserVo;
+
+@Service("userService")
+public class UserServiceImpl implements UserService {
+
+    @Autowired
+    SqlSessionTemplate sqlSessionTemplate;
+
+    @Override
+    public UserVo login(String username, String password) {
+        Map<String, Object> param = new HashMap<>();
+        param.put("username", username);
+        param.put("password", password);
+        return sqlSessionTemplate.selectOne("selectUserByUsernameAndPassword", param);
+    }
+}

--- a/src/main/java/forest/user/vo/UserVo.java
+++ b/src/main/java/forest/user/vo/UserVo.java
@@ -1,0 +1,38 @@
+package forest.user.vo;
+
+import java.util.Date;
+
+public class UserVo {
+    private Long userId;
+    private String username;
+    private String password;
+    private String email;
+    private String role;
+    private Boolean enabled;
+    private Date createdAt;
+    private Date updatedAt;
+
+    public Long getUserId() { return userId; }
+    public void setUserId(Long userId) { this.userId = userId; }
+
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+
+    public String getRole() { return role; }
+    public void setRole(String role) { this.role = role; }
+
+    public Boolean getEnabled() { return enabled; }
+    public void setEnabled(Boolean enabled) { this.enabled = enabled; }
+
+    public Date getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
+
+    public Date getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(Date updatedAt) { this.updatedAt = updatedAt; }
+}

--- a/src/main/java/forest/user/web/LoginController.java
+++ b/src/main/java/forest/user/web/LoginController.java
@@ -1,0 +1,45 @@
+package forest.user.web;
+
+import javax.servlet.http.HttpSession;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import forest.user.service.UserService;
+import forest.user.vo.UserVo;
+
+@Controller
+public class LoginController {
+
+    @Autowired
+    UserService userService;
+
+    @GetMapping("/login")
+    public String loginForm() {
+        return "login";
+    }
+
+    @PostMapping("/login")
+    public String login(@RequestParam("username") String username,
+                        @RequestParam("password") String password,
+                        HttpSession session,
+                        Model model) {
+        UserVo user = userService.login(username, password);
+        if (user != null && Boolean.TRUE.equals(user.getEnabled())) {
+            session.setAttribute("loginUser", user);
+            return "redirect:/nuriview_yi/selectKiosk.do";
+        }
+        model.addAttribute("error", "Invalid credentials");
+        return "login";
+    }
+
+    @GetMapping("/logout")
+    public String logout(HttpSession session) {
+        session.invalidate();
+        return "redirect:/login";
+    }
+}

--- a/src/main/resources/dbconfig/mybatis-config.xml
+++ b/src/main/resources/dbconfig/mybatis-config.xml
@@ -10,10 +10,11 @@
 	<!-- <typeAliases> -->
 	<!-- <typeAlias alias="KioskCol" type="forest.kiosk.vo.KioskCol" /> -->
 	<!-- </typeAliases> -->
-	<typeAliases>
-		<!-- <package name="app.web.vo" /> -->
-		<typeAlias alias="KioskCol" type="forest.kiosk.vo.KioskCol" />
-		<typeAlias alias="KioskVo" type="forest.kiosk.vo.KioskVo" />
-	</typeAliases>
+        <typeAliases>
+                <!-- <package name="app.web.vo" /> -->
+                <typeAlias alias="KioskCol" type="forest.kiosk.vo.KioskCol" />
+                <typeAlias alias="KioskVo" type="forest.kiosk.vo.KioskVo" />
+                <typeAlias alias="UserVo" type="forest.user.vo.UserVo" />
+        </typeAliases>
 
 </configuration>

--- a/src/main/resources/mappers/user.xml
+++ b/src/main/resources/mappers/user.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd" >
+<mapper namespace="UserMapper">
+
+<select id="selectUserByUsernameAndPassword" parameterType="map" resultType="UserVo">
+SELECT
+    user_id,
+    username,
+    password,
+    email,
+    role,
+    enabled,
+    created_at,
+    updated_at
+FROM user
+WHERE username = #{username}
+  AND password = #{password}
+</select>
+
+</mapper>

--- a/src/main/webapp/WEB-INF/views/login.jsp
+++ b/src/main/webapp/WEB-INF/views/login.jsp
@@ -1,0 +1,18 @@
+<%@ page contentType="text/html;charset=UTF-8"%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<html>
+<head>
+    <title>Login</title>
+</head>
+<body>
+    <h2>Login</h2>
+    <c:if test="${not empty error}">
+        <div style="color:red">${error}</div>
+    </c:if>
+    <form method="post" action="/login">
+        <label>Username: <input type="text" name="username"/></label><br/>
+        <label>Password: <input type="password" name="password"/></label><br/>
+        <button type="submit">Login</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- introduce `UserVo` and a simple MyBatis mapper for user lookups
- implement `UserService` with login support
- add `LoginController` and JSP page to handle login/logout
- register `UserVo` alias in MyBatis config

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6846a00a0d0c83238c07b51fb65fd38e