### PR TITLE
Add user list page with pagination

### DIFF
--- a/src/main/java/forest/user/service/UserService.java
+++ b/src/main/java/forest/user/service/UserService.java
@@ -5,4 +5,6 @@ import forest.user.vo.UserVo;
 public interface UserService {
     UserVo login(String username, String password);
     int register(UserVo user);
+    java.util.List<UserVo> selectUserList(int offset, int limit);
+    int countUsers();
 }

--- a/src/main/java/forest/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/forest/user/service/impl/UserServiceImpl.java
@@ -39,4 +39,18 @@ public class UserServiceImpl implements UserService {
         logger.debug("register called for user '{}'", user.getUsername());
         return sqlSessionTemplate.insert("insertUser", user);
     }
+
+    @Override
+    public java.util.List<UserVo> selectUserList(int offset, int limit) {
+        Map<String, Object> param = new HashMap<>();
+        param.put("offset", offset);
+        param.put("limit", limit);
+        return sqlSessionTemplate.selectList("selectUserList", param);
+    }
+
+    @Override
+    public int countUsers() {
+        Integer cnt = sqlSessionTemplate.selectOne("countUsers");
+        return cnt == null ? 0 : cnt;
+    }
 }

--- a/src/main/java/forest/user/web/UserController.java
+++ b/src/main/java/forest/user/web/UserController.java
@@ -1,0 +1,38 @@
+package forest.user.web;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import forest.user.service.UserService;
+import forest.user.vo.UserVo;
+import jakarta.servlet.http.HttpSession;
+
+@Controller
+public class UserController {
+
+    @Autowired
+    UserService userService;
+
+    @GetMapping("/users")
+    public String list(@RequestParam(name = "page", defaultValue = "1") int page,
+                       Model model, HttpSession session) {
+        if (session.getAttribute("loginUser") == null) {
+            return "redirect:/login";
+        }
+        int pageSize = 10;
+        int offset = (page - 1) * pageSize;
+        List<UserVo> users = userService.selectUserList(offset, pageSize);
+        int total = userService.countUsers();
+        int totalPages = (int) Math.ceil((double) total / pageSize);
+
+        model.addAttribute("users", users);
+        model.addAttribute("currentPage", page);
+        model.addAttribute("totalPages", totalPages);
+        return "forest/user";
+    }
+}

--- a/src/main/resources/mappers/user.xml
+++ b/src/main/resources/mappers/user.xml
@@ -16,24 +16,42 @@
 		AND password = #{password}
 	</select>
 
-	<insert id="insertUser" parameterType="UserVo" useGeneratedKeys="true" keyProperty="userId">
-		INSERT INTO user (
-		username,
-		password,
-		email,
-		role,
-		enabled,
-		created_at,
-		updated_at
-		) VALUES (
-		#{username},
-		#{password},
-		#{email},
-		#{role},
-		#{enabled},
-		NOW(),
-		NOW()
-		)
-	</insert>
+        <insert id="insertUser" parameterType="UserVo" useGeneratedKeys="true" keyProperty="userId">
+                INSERT INTO user (
+                username,
+                password,
+                email,
+                role,
+                enabled,
+                created_at,
+                updated_at
+                ) VALUES (
+                #{username},
+                #{password},
+                #{email},
+                #{role},
+                #{enabled},
+                NOW(),
+                NOW()
+                )
+        </insert>
+
+        <select id="selectUserList" parameterType="map" resultType="UserVo">
+                SELECT
+                user_id,
+                username,
+                email,
+                role,
+                enabled,
+                created_at,
+                updated_at
+                FROM user
+                ORDER BY user_id
+                LIMIT #{limit} OFFSET #{offset}
+        </select>
+
+        <select id="countUsers" resultType="int">
+                SELECT COUNT(*) FROM user
+        </select>
 
 </mapper>

--- a/src/main/webapp/WEB-INF/views/forest/layout.jsp
+++ b/src/main/webapp/WEB-INF/views/forest/layout.jsp
@@ -44,6 +44,12 @@
               <p>Kiosk</p>
             </a>
           </li>
+          <li class="nav-item">
+            <a href="<c:url value='/users'/>" class="nav-link">
+              <i class="nav-icon fas fa-users"></i>
+              <p>Users</p>
+            </a>
+          </li>
         </ul>
       </nav>
     </div>

--- a/src/main/webapp/WEB-INF/views/forest/user.jsp
+++ b/src/main/webapp/WEB-INF/views/forest/user.jsp
@@ -1,0 +1,3 @@
+<jsp:include page="layout.jsp">
+  <jsp:param name="content" value="userContent.jsp"/>
+</jsp:include>

--- a/src/main/webapp/WEB-INF/views/forest/userContent.jsp
+++ b/src/main/webapp/WEB-INF/views/forest/userContent.jsp
@@ -1,0 +1,52 @@
+<div class="content-header">
+  <div class="container-fluid">
+    <div class="row mb-2">
+      <div class="col-sm-6">
+        <h1 class="m-0">User List</h1>
+      </div>
+    </div>
+  </div>
+</div>
+<section class="content">
+  <div class="container-fluid">
+    <div class="card">
+      <div class="card-body">
+        <div class="table-responsive">
+          <table class="table table-striped table-sm">
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Username</th>
+                <th>Email</th>
+                <th>Role</th>
+                <th>Enabled</th>
+                <th>Created At</th>
+              </tr>
+            </thead>
+            <tbody>
+              <c:forEach var="user" items="${users}">
+                <tr>
+                  <td>${user.userId}</td>
+                  <td>${user.username}</td>
+                  <td>${user.email}</td>
+                  <td>${user.role}</td>
+                  <td>${user.enabled}</td>
+                  <td><fmt:formatDate value="${user.createdAt}" pattern="yyyy-MM-dd HH:mm:ss"/></td>
+                </tr>
+              </c:forEach>
+            </tbody>
+          </table>
+        </div>
+        <nav>
+          <ul class="pagination justify-content-center">
+            <c:forEach var="p" begin="1" end="${totalPages}">
+              <li class="page-item ${p == currentPage ? 'active' : ''}">
+                <a class="page-link" href="<c:url value='/users?page=${p}'/>">${p}</a>
+              </li>
+            </c:forEach>
+          </ul>
+        </nav>
+      </div>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- add menu item for user list to sidebar
- implement `UserController` and extend `UserService`
- support retrieving user list and user count in service layer and MyBatis mapper
- add JSP pages `user.jsp` and `userContent.jsp`

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68494482e54c8323bc655842ac6df00e